### PR TITLE
Change bouncer `not-found` message

### DIFF
--- a/utils/transcript.yml
+++ b/utils/transcript.yml
@@ -26,4 +26,4 @@ application-committee:
   rejected: Ooof, this team was just rejected. I pity the fool.
 bouncer-checkin:
   found: consider yourself present <@${this.user}>, now run along and join your team in <#${this.channel}>
-  not-found: what kinda crazy mumbo-jumbo nonsense is this?? I could find a solid _nobody_ in our applications database with the registration passphrase "${this.pass}". try again, fool.
+  not-found: listen up fool - we closed up this here checkin joint. If for some reason you've been directed to post this code in here, someone on our A-team made a mistake. Send that code on over to clubs@hackclub.com instead and those suckers will patch it right up.


### PR DESCRIPTION
https://hackclub.slack.com/archives/CM08L302G/p1632498736038100

This PR changes the `not-found` message for @bouncer, so people who post in #bouncer-checkin will know what to do if they post a code there and don't check the pinned messages.